### PR TITLE
Adding configuration permission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "flyingferret/seat-whtools",
+  "name": "lk77/seat-whtools",
   "description": "Wormhole corporation tools for SeAT",
   "type": "seat-plugin",
   "license": "GPL-2.0-only",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "lk77/seat-whtools",
+  "name": "flyingferret/seat-whtools",
   "description": "Wormhole corporation tools for SeAT",
   "type": "seat-plugin",
   "license": "GPL-2.0-only",

--- a/src/Config/whtools.permissions.php
+++ b/src/Config/whtools.permissions.php
@@ -22,7 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 return [
 
     'whtools' => [
-        'stockview', 'stockedit', 'bluetaxview', 'certview', 'certchecker', 'certManager'
+        'stockview', 'stockedit', 'bluetaxview', 'certview', 'certchecker', 'certManager', 'configuration'
     ],
 
 ];

--- a/src/Config/whtools.sidebar.php
+++ b/src/Config/whtools.sidebar.php
@@ -46,7 +46,7 @@ return [
                 'label' => 'web::seat.configuration',
                 'icon' => 'fa fa-cog',
                 'route' => 'whtools.config',
-                'permission' => 'whtools.bluetaxview'
+                'permission' => 'whtools.configuration'
             ],
             [
                 'name' => 'Certificates',


### PR DESCRIPTION
Hello,

we would like to add a permission for configuration page of whtools, currently it's the bluetax permission that is used for this page,

if you want to try it out, install lk77/seat-whtools 0.2.1

i was forced to add my fork on packagist since i cant add a vcs repository in seat composer.json, i will delete it if merged.

And note that it is a breaking change, users will need to add that permission to their roles.

thanks.